### PR TITLE
Fixed package name in readme.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ __Composer (recommend)__
 You can install CouchDB Client over composer. Add the following line into your ```composer.json``` file.
 
 ```
-$ composer require baachi/couchdb
+$ composer require bachi/couchdb
 ```
 
 __Git__


### PR DESCRIPTION
The package name was wrong: https://packagist.org/packages/bachi/couchdb

Hope this was not a typo :|